### PR TITLE
Configure PhantomJS to ignore ssl errors.

### DIFF
--- a/dpxdt/client/capture_worker.py
+++ b/dpxdt/client/capture_worker.py
@@ -89,6 +89,7 @@ class CaptureWorkflow(process_worker.ProcessWorkflow):
             FLAGS.phantomjs_binary,
             '--disk-cache=false',
             '--debug=true',
+            '--ignore-ssl-errors=true',
             FLAGS.phantomjs_script,
             self.config_path,
             self.output_path,


### PR DESCRIPTION
Resolves [Issue #43](https://github.com/bslatkin/dpxdt/issues/43): Unable to take screenshots of pages requiring SSL
